### PR TITLE
Fixing multus-pod manifest adding myfristpod

### DIFF
--- a/manifests/myfirstpod.yaml
+++ b/manifests/myfirstpod.yaml
@@ -3,14 +3,13 @@ kind: Pod
 metadata:
   creationTimestamp: null
   labels:
-    run: multus-pod
-  name: multus-pod
-  annotations:
-    k8s.v1.cni.cncf.io/networks: macvlan-conf
+    run: myfirstpod
+  name: myfirstpod
+  namespace: basic
 spec:
   containers:
   - image: busybox
-    name: multus-pod
+    name: myfirstpod
     command: ["/bin/sh", "-c", "while true; do echo hello; sleep 10; done"]
     resources: {}
   dnsPolicy: ClusterFirst


### PR DESCRIPTION
Adding myfirstpod manifest as it was missing
modifying multus-pod to be deployed on default ns

Signed-off-by: Ondřej Šmalec <ondra.smalec@gmail.com>